### PR TITLE
allow rebuilding from webpack script

### DIFF
--- a/lib/Mojolicious/Command/Author/webpack.pm
+++ b/lib/Mojolicious/Command/Author/webpack.pm
@@ -55,7 +55,8 @@ sub _parse_argv {
     'l|listen=s'  => \my @listen,
     'm|mode=s'    => \$ENV{MOJO_MODE},
     'v|verbose'   => \$ENV{MORBO_VERBOSE},
-    'w|watch=s'   => \my @watch;
+    'w|watch=s'   => \my @watch,
+    'r|rebuild'   => \$ENV{MOJO_WEBPACK_REINSTALL};
 
   # Need to run "mojo webpack" and not "./myapp.pl webpack" to have a clean environment
   $self->_exec_mojo_webpack($self->_script_name, @orig_argv) if path($self->_script_name)->basename ne 'mojo';

--- a/lib/Mojolicious/Plugin/Webpack/webpack.config.js
+++ b/lib/Mojolicious/Plugin/Webpack/webpack.config.js
@@ -19,7 +19,7 @@ const config = {
     minimizer: []
   },
   output: {
-    filename: isDev ? '[name].dev.js' : '[name].[chunkhash].js',
+    filename: isDev ? '[name].development.js' : '[name].[chunkhash].js',
     path: outDir
   },
   plugins: [
@@ -52,7 +52,7 @@ if (process.env.WEBPACK_RULE_FOR_JS) {
 if (process.env.WEBPACK_RULE_FOR_CSS || process.env.WEBPACK_RULE_FOR_SASS) {
   var MiniCssExtractPlugin = require('mini-css-extract-plugin');
   config.plugins.push(new MiniCssExtractPlugin({
-    filename: isDev ? '[name].dev.css' : '[name].[contenthash].css',
+    filename: isDev ? '[name].development.css' : '[name].[contenthash].css',
   }));
 
   const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');


### PR DESCRIPTION
Hello @jhthorsen,

I missed an option to easy install additional npm modules during development by setting the MOJO_WEBPACK_REINSTALL from webpack.

Greets,

Mario Minati 