### PR TITLE
Fix examples to run from checkout and with newer codes

### DIFF
--- a/example/rollup/README.pod
+++ b/example/rollup/README.pod
@@ -1,0 +1,66 @@
+=encoding utf8
+
+=head1 Webpack Example - Rollup/Svelte Demo
+
+This example demonstrates using L<rollup.js|https://rollupjs.org> for a
+L<svelte.js|http://sveltejs.com> app.
+
+=head1 Running the Example
+
+The example only requires the dependencies to be installed and a clone of the
+`Mojolicious::Plugin::Webpack` code.
+
+=head2 Carton
+
+With L<Carton> installed from CPAN, the example is most easily started,
+beginning in the `example/rollup` directory, by following:
+
+  $ carton install
+  $ carton exec ./lite.pl webpack
+  Server available at http://127.0.0.1:3000
+
+The example can be viewed by visiting the listed L<URL|http://127.0.0.1:3000> in
+a browser.
+
+=head2 perlbrew and cpanm
+
+With L<perlbrew|App::perlbrew> and L<cpanm> installed from CPAN, the example
+is most easily started, beginning in the `mojolicious-plugin-webpack` directory,
+by following:
+
+  $ cpanm --installdeps -n -q .
+  $ cd example/rollup
+  $ ./lite.pl webpack
+  Server available at http://127.0.0.1:3000
+
+The example can be viewed by visiting the listed L<URL|http://127.0.0.1:3000> in
+a browser.
+
+=head1 Environment Variables
+
+As documented in L<Mojolicious::Plugin::Webpack::Builder> the following
+environment variables influence the behaviour of the `lite.pl` application.
+
+=over 4
+
+=item MOJO_NPM_BINARY
+
+=item MOJO_WEBPACK_BINARY
+
+=item MOJO_WEBPACK_CONFIG
+
+=item MOJO_WEBPACK_REINSTALL
+
+=item MOJO_WEBPACK_VERBOSE
+
+This should not be used for this example. An error will result, similar to
+
+  (!) You have passed an unrecognized option
+  Unknown CLI flag: ...
+
+=back
+
+Additionally, C<MOJO_WEBPACK_DEBUG> may be set to a true value to increase the
+level of diagnostic messages displayed.
+
+=cut

--- a/example/rollup/lite.pl
+++ b/example/rollup/lite.pl
@@ -1,12 +1,29 @@
 #!/usr/bin/env perl
 use Mojolicious::Lite;
-use FindBin;
-BEGIN { unshift @INC, "$FindBin::Bin/../../lib" }
+use Mojo::File 'curfile';
+require lib;
 
-plugin Webpack =>
-  {process => ['svelte'], dependencies => {core => 'rollup', svelte => [qw(rollup-plugin-svelte svelte)]}};
+$ENV{MOJO_WEBPACK_CONFIG}  = "@{[curfile->sibling('rollup.config.js')]}";
+$ENV{MOJO_WEBPACK_DEBUG}   = 1;
+$ENV{MOJO_WEBPACK_VERBOSE} = 0;
+$ENV{MOJO_WEBPACK_LAZY}    = 0;
+
+my $path = "@{[curfile->dirname->dirname->sibling('lib')]}";
+lib->import($path);
+
+plugin Webpack => {
+  process      => ['svelte'],
+  dependencies => {
+    core   => 'rollup',
+    svelte => [qw(rollup-plugin-svelte svelte)]
+  }
+};
 get '/' => 'index';
-app->start;
+
+{
+  local $ENV{PERL5OPT} = "-I$path";
+  app->start;
+}
 
 __DATA__
 @@ index.html.ep
@@ -14,7 +31,7 @@ __DATA__
 <html>
   <head>
     <title>Mojolicious ♥ Webpack</title>
-    %= asset 'example.css'
+    % # asset 'example.css'
   </head>
   <body>
     <h1>Mojolicious ♥ Rollup</h1>

--- a/example/rollup/lite.pl
+++ b/example/rollup/lite.pl
@@ -3,25 +3,20 @@ use Mojolicious::Lite;
 use Mojo::File 'curfile';
 require lib;
 
-$ENV{MOJO_WEBPACK_CONFIG}  = "@{[curfile->sibling('rollup.config.js')]}";
-$ENV{MOJO_WEBPACK_DEBUG}   = 1;
-$ENV{MOJO_WEBPACK_VERBOSE} = 0;
-$ENV{MOJO_WEBPACK_LAZY}    = 0;
+$ENV{MOJO_WEBPACK_CONFIG} = "@{[curfile->sibling('rollup.config.js')]}";
 
-my $path = "@{[curfile->dirname->dirname->sibling('lib')]}";
-lib->import($path);
+my $lib_path = "@{[curfile->dirname->dirname->sibling('lib')]}";
+lib->import($lib_path);
 
 plugin Webpack => {
-  process      => ['svelte'],
-  dependencies => {
-    core   => 'rollup',
-    svelte => [qw(rollup-plugin-svelte svelte)]
-  }
+  process => ['svelte'],
+  dependencies =>
+    {core => 'rollup', svelte => [qw(rollup-plugin-svelte svelte)]}
 };
 get '/' => 'index';
 
 {
-  local $ENV{PERL5OPT} = "-I$path";
+  local $ENV{PERL5OPT} = "-I$lib_path";
   app->start;
 }
 

--- a/example/rollup/rollup.config.js
+++ b/example/rollup/rollup.config.js
@@ -1,11 +1,11 @@
-import commonjs from 'rollup-plugin-commonjs';
+import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import {terser} from 'rollup-plugin-terser';
 
 // The html plugin generates a file that M::P::Webpack reads to generate the
 // correct output when calling <%= asset 'example.js' %> and
 // <%= asset 'example.css' %>
-const html = require('@rollup/plugin-html');
+import html from '@rollup/plugin-html';
 
 // This example app use https://svelte.dev/, so we need to load that plugin
 import svelte from 'rollup-plugin-svelte';

--- a/example/rollup/rollup.config.js
+++ b/example/rollup/rollup.config.js
@@ -1,11 +1,11 @@
 import commonjs from 'rollup-plugin-commonjs';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import {terser} from 'rollup-plugin-terser';
 
 // The html plugin generates a file that M::P::Webpack reads to generate the
 // correct output when calling <%= asset 'example.js' %> and
 // <%= asset 'example.css' %>
-import html from 'rollup-plugin-bundle-html';
+const html = require('@rollup/plugin-html');
 
 // This example app use https://svelte.dev/, so we need to load that plugin
 import svelte from 'rollup-plugin-svelte';
@@ -45,10 +45,7 @@ export default {
     production && terser(),
 
     html({
-      dest,
-      filename: 'webpack.' + (production ? 'production' : 'development') + '.html',
-      inject: 'head',
-      template: '<html><head></head><body></body></html>',
+      fileName: 'webpack.' + (production ? 'production' : 'development') + '.html',
     }),
   ],
   watch: {

--- a/example/webpack/README.pod
+++ b/example/webpack/README.pod
@@ -1,0 +1,61 @@
+=encoding utf8
+
+=head1 Webpack Example - Webpack/Vue Demo
+
+This example demonstrates using L<webpack|https://webpack.js.org> for a
+L<vue.js|https://vuejs.org> app.
+
+=head1 Running the Example
+
+The example only requires the dependencies to be installed and a clone of the
+`Mojolicious::Plugin::Webpack` code.
+
+=head2 Carton
+
+With L<Carton> installed from CPAN, the example is most easily started,
+beginning in the `example/webpack` directory, by following:
+
+  $ carton install
+  $ carton exec ./lite.pl webpack
+  Server available at http://127.0.0.1:3000
+
+The example can be viewed by visiting the listed L<URL|http://127.0.0.1:3000> in
+a browser.
+
+=head2 perlbrew and cpanm
+
+With L<perlbrew|App::perlbrew> and L<cpanm> installed from CPAN, the example
+is most easily started, beginning in the `mojolicious-plugin-webpack` directory,
+by following:
+
+  $ cpanm --installdeps -n -q .
+  $ cd example/webpack
+  $ ./lite.pl webpack
+  Server available at http://127.0.0.1:3000
+
+The example can be viewed by visiting the listed L<URL|http://127.0.0.1:3000> in
+a browser.
+
+=head1 Environment Variables
+
+As documented in L<Mojolicious::Plugin::Webpack::Builder> the following
+environment variables influence the behaviour of the `lite.pl` application.
+
+=over 4
+
+=item MOJO_NPM_BINARY
+
+=item MOJO_WEBPACK_BINARY
+
+=item MOJO_WEBPACK_CONFIG
+
+=item MOJO_WEBPACK_REINSTALL
+
+=item MOJO_WEBPACK_VERBOSE
+
+=back
+
+Additionally, C<MOJO_WEBPACK_DEBUG> may be set to a true value to increase the
+level of diagnostic messages displayed.
+
+=cut

--- a/example/webpack/lite.pl
+++ b/example/webpack/lite.pl
@@ -1,11 +1,18 @@
 #!/usr/bin/env perl
 use Mojolicious::Lite;
-use FindBin;
-BEGIN { unshift @INC, "$FindBin::Bin/../../lib" }
+use Mojo::File 'curfile';
+require lib;
+
+my $path = "@{[curfile->dirname->dirname->sibling('lib')]}";
+lib->import($path);
 
 plugin Webpack => {process => [qw(js css sass vue)]};
 get '/'        => 'index';
-app->start;
+
+{
+  local $ENV{PERL5OPT} = "-I$path";
+  app->start;
+}
 
 __DATA__
 @@ index.html.ep

--- a/lib/Mojolicious/Plugin/Webpack/Builder.pm
+++ b/lib/Mojolicious/Plugin/Webpack/Builder.pm
@@ -85,7 +85,7 @@ sub _install_node_deps {
 
   if ($self->dependencies->{core} eq 'rollup') {
     $self->dependencies->{core}
-      = [qw(rollup rollup-plugin-node-resolve rollup-plugin-commonjs rollup-plugin-terser rollup-plugin-bundle-html)];
+      = [qw(rollup @rollup/plugin-node-resolve rollup-plugin-commonjs rollup-plugin-terser @rollup/plugin-html)];
   }
 
   for my $preset ('core', @{$self->process}) {

--- a/lib/Mojolicious/Plugin/Webpack/Builder.pm
+++ b/lib/Mojolicious/Plugin/Webpack/Builder.pm
@@ -85,7 +85,7 @@ sub _install_node_deps {
 
   if ($self->dependencies->{core} eq 'rollup') {
     $self->dependencies->{core}
-      = [qw(rollup @rollup/plugin-node-resolve rollup-plugin-commonjs rollup-plugin-terser @rollup/plugin-html)];
+      = [qw(rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs rollup-plugin-terser @rollup/plugin-html)];
   }
 
   for my $preset ('core', @{$self->process}) {

--- a/lib/Mojolicious/Plugin/Webpack/webpack.config.js
+++ b/lib/Mojolicious/Plugin/Webpack/webpack.config.js
@@ -75,7 +75,11 @@ if (process.env.WEBPACK_RULE_FOR_SASS) {
     use: [
       MiniCssExtractPlugin.loader,
       {loader: 'css-loader', options: {sourceMap: sourceMap}},
-      {loader: 'sass-loader', options: {includePaths: sassIncludePaths, sourceMap: sourceMap}}
+      {loader: 'sass-loader', options: {
+        implementation: require('node-sass'),
+        sassOptions: {includePaths: sassIncludePaths, sourceMap: sourceMap}
+        }
+      }
     ]
   });
 }


### PR DESCRIPTION
The examples lead to errors when running from a checkout.

```
Unknown command "webpack", maybe you need to install it?
```

Various `webpack` and `rollup` config/plugin related errors are also fixed, including #4.

