### PR TITLE
fix Routes::Route::route deprecation for Mojolicious 8.67+

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.pl linguist-language=Perl
+*.pm linguist-language=Perl
+*.t linguist-language=Perl

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install node 14.x on perl's container
-      - run: |
+        run: |
           apt-get update
           apt-get install -y curl
           curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -6,12 +6,17 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.30'
+          - "5.30"
     container:
       image: perl:${{matrix.perl-version}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - name: install node 14.x on perl's container
+      - run: |
+          apt-get update
+          apt-get install -y curl
+          curl -sL https://deb.nodesource.com/setup_14.x | bash -
+          apt-get install -y nodejs
       - name: perl -V
         run: perl -V
       - name: Fix ExtUtils::MakeMaker (for Perl 5.16 and 5.18)
@@ -27,3 +32,5 @@ jobs:
           TEST_ALL: 1
           TEST_POD: 1
           TEST_PUBSUB: 1
+      - name: webpack version
+        run: ./t/node_modules/.bin/webpack --version

--- a/lib/Mojolicious/Plugin/Webpack.pm
+++ b/lib/Mojolicious/Plugin/Webpack.pm
@@ -18,7 +18,7 @@ sub route      { shift->{route} }
 
 sub register {
   my ($self, $app, $config) = @_;
-  $self->{route} = $app->routes->route('/asset/*name')->via(qw(HEAD GET))->name('webpack.asset');
+  $self->{route} = $app->routes->any('/asset/*name')->methods(qw(HEAD GET))->name('webpack.asset');
 
   $self->{$_} = path $config->{$_} for grep { $config->{$_} } qw(assets_dir out_dir);
   $self->{node_env} = $config->{node_env} || ($app->mode eq 'development' ? 'development' : 'production');

--- a/lib/Mojolicious/Plugin/Webpack/Builder.pm
+++ b/lib/Mojolicious/Plugin/Webpack/Builder.pm
@@ -14,9 +14,9 @@ our $VERSION = $Mojolicious::Plugin::Webpack::VERSION || '0.01';
 
 has dependencies => sub {
   return {
-    core => [qw(webpack webpack-cli webpack-plugin-hash-output html-webpack-plugin)],
-    css  => [qw(css-loader mini-css-extract-plugin optimize-css-assets-webpack-plugin)],
-    js   => [qw(@babel/core @babel/preset-env babel-loader terser-webpack-plugin)],
+    core => [qw(webpack webpack-cli html-webpack-plugin@next)],
+    css  => [qw(css-loader mini-css-extract-plugin css-minimizer-webpack-plugin)],
+    js   => [qw(@babel/core @babel/preset-env babel-loader)],
     sass => [qw(node-sass sass-loader)],
     vue  => [qw(vue vue-loader vue-template-compiler)],
   };
@@ -51,7 +51,7 @@ sub register {
   else {
     $self->_render_to_file($app, 'webpack.config.js');
     $self->_render_to_file($app, 'webpack.custom.js', $self->_custom_file);
-    $self->_render_to_file($app, 'my_app.js', $self->assets_dir->child('my_app.js'))
+    $self->_render_to_file($app, 'my_app.js',         $self->assets_dir->child('my_app.js'))
       if $self->{files}{'webpack.custom.js'}[0] eq 'generated';
   }
 
@@ -305,8 +305,8 @@ it depends on. Example:
 
   $app->plugin("Webpack" => {
     dependencies => {
-      css  => [qw(css-loader mini-css-extract-plugin optimize-css-assets-webpack-plugin)],
-      js   => [qw(@babel/core @babel/preset-env babel-loader terser-webpack-plugin)],
+      css  => [qw(css-loader mini-css-extract-plugin css-minimizer-webpack-plugin)],
+      js   => [qw(@babel/core @babel/preset-env babel-loader)],
       sass => [qw(node-sass sass-loader)],
     }
   });

--- a/lib/Mojolicious/Plugin/Webpack/webpack.config.js
+++ b/lib/Mojolicious/Plugin/Webpack/webpack.config.js
@@ -8,7 +8,6 @@ const shareDir = process.env.WEBPACK_SHARE_DIR || './assets';
 const sourceMap = process.env.WEBPACK_SOURCE_MAPS ? true : isDev ? true : false;
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const HashOutput = require('webpack-plugin-hash-output');
 
 const config = {
   mode: isDev ? 'development' : 'production',
@@ -23,7 +22,6 @@ const config = {
     path: outDir
   },
   plugins: [
-    new HashOutput(),
     new HtmlWebpackPlugin({
       cache: true,
       filename: './webpack.' + (process.env.WEBPACK_CUSTOM_NAME ? process.env.WEBPACK_CUSTOM_NAME : isDev ? 'development' : 'production') + '.html',
@@ -39,7 +37,7 @@ const config = {
 
 if (process.env.WEBPACK_RULE_FOR_JS) {
   const TerserPlugin = require('terser-webpack-plugin');
-  config.optimization.minimizer.push(new TerserPlugin({cache: true, parallel: true, sourceMap: sourceMap}));
+  config.optimization.minimizer.push(new TerserPlugin({ parallel: true }));
   config.module.rules.push({
     test: /\.js$/,
     exclude: /node_modules/,
@@ -55,7 +53,7 @@ if (process.env.WEBPACK_RULE_FOR_CSS || process.env.WEBPACK_RULE_FOR_SASS) {
     filename: isDev ? '[name].development.css' : '[name].[contenthash].css',
   }));
 
-  const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+  const OptimizeCSSAssetsPlugin = require('css-minimizer-webpack-plugin');
   config.optimization.minimizer.push(new OptimizeCSSAssetsPlugin({}));
 }
 
@@ -64,7 +62,7 @@ if (process.env.WEBPACK_RULE_FOR_CSS) {
     test: /\.css$/,
     use: [
       MiniCssExtractPlugin.loader,
-      {loader: 'css-loader', options: {sourceMap: true}}
+      { loader: 'css-loader', options: { sourceMap: true } }
     ]
   });
 }
@@ -74,8 +72,8 @@ if (process.env.WEBPACK_RULE_FOR_SASS) {
     test: /\.s(a|c)ss$/,
     use: [
       MiniCssExtractPlugin.loader,
-      {loader: 'css-loader', options: {sourceMap: sourceMap}},
-      {loader: 'sass-loader', options: {sassOptions: {includePaths: sassIncludePaths}, sourceMap: sourceMap}}
+      { loader: 'css-loader', options: { sourceMap: sourceMap } },
+      { loader: 'sass-loader', options: { sassOptions: { includePaths: sassIncludePaths }, sourceMap: sourceMap } }
     ]
   });
 }

--- a/t/public/asset/webpack.development.html
+++ b/t/public/asset/webpack.development.html
@@ -1,8 +1,60 @@
-<!DOCTYPE html>
-<html>
-  <head><title>Webpack</title><link href="myapp.development.css" rel="stylesheet"><script type="text/javascript" src="myapp.development.js"></script></head>
-  <body>
-    <h1>Webpack output files</h1>
-    <p>This file has all the generated assets in &lt;head></p>
-  </body>
-</html>
+<head><script src="myapp.development.js"></script></head>Html Webpack Plugin:
+<pre>
+  Error: Child compilation failed:
+  Module not found: Error: Can't resolve '/Users/daniel/mojolicious-plugin-webpack/t/assets/webpack.html' in '/Users/daniel/moj  olicious-plugin-webpack/t':
+  Error: Can't resolve '/Users/daniel/mojolicious-plugin-webpack/t/assets/webpack.html' in '/Users/daniel/mojolicious-plugin-we  bpack/t'
+  ModuleNotFoundError: Module not found: Error: Can't resolve '/Users/daniel/mojolicious-plugin-webpack/t/assets/webpack.html'   in '/Users/daniel/mojolicious-plugin-webpack/t'
+  
+  - Compilation.js:1570 
+    [t]/[webpack]/lib/Compilation.js:1570:28
+  
+  - NormalModuleFactory.js:648 
+    [t]/[webpack]/lib/NormalModuleFactory.js:648:13
+  
+  
+  - NormalModuleFactory.js:233 
+    [t]/[webpack]/lib/NormalModuleFactory.js:233:22
+  
+  
+  - NormalModuleFactory.js:357 
+    [t]/[webpack]/lib/NormalModuleFactory.js:357:22
+  
+  - NormalModuleFactory.js:116 
+    [t]/[webpack]/lib/NormalModuleFactory.js:116:11
+  
+  - NormalModuleFactory.js:577 
+    [t]/[webpack]/lib/NormalModuleFactory.js:577:24
+  
+  - NormalModuleFactory.js:721 
+    [t]/[webpack]/lib/NormalModuleFactory.js:721:5
+  
+  - Resolver.js:296 finishWithoutResolve
+    [t]/[enhanced-resolve]/lib/Resolver.js:296:11
+  
+  - child-compiler.js:131 
+    [t]/[html-webpack-plugin]/lib/child-compiler.js:131:18
+  
+  - Compiler.js:511 
+    [t]/[webpack]/lib/Compiler.js:511:11
+  
+  - Compiler.js:1059 
+    [t]/[webpack]/lib/Compiler.js:1059:17
+  
+  
+  - Hook.js:18 Hook.CALL_ASYNC_DELEGATE [as _callAsync]
+    [t]/[tapable]/lib/Hook.js:18:14
+  
+  - Compiler.js:1055 
+    [t]/[webpack]/lib/Compiler.js:1055:33
+  
+  - Compilation.js:2121 
+    [t]/[webpack]/lib/Compilation.js:2121:10
+  
+  
+  - Hook.js:18 Hook.CALL_ASYNC_DELEGATE [as _callAsync]
+    [t]/[tapable]/lib/Hook.js:18:14
+  
+  - Compilation.js:2114 
+    [t]/[webpack]/lib/Compilation.js:2114:37
+  
+</pre>


### PR DESCRIPTION
Starting on Mojolicious 8.67, Mojolicious::Routes::Route::route is deprecated in favor of Mojolicious::Routes::Route::any. This PR is to use new recommended way (any instead of route, methods instead of via).

Also adds .gitattributes file to help github detect Perl language (instead of marking files as Raku's)