### PR TITLE
recognize Perl language file extensions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.pl linguist-language=Perl
+*.pm linguist-language=Perl
+*.t linguist-language=Perl


### PR DESCRIPTION
Github statistics for the repo shows 48% Raku, and this is not correct. This PR fixes that, making Github consider all *.pm, *.pl and *.t files as Perl sources.