### PR TITLE
migrate to webpack 5

### DIFF
--- a/lib/Mojolicious/Plugin/Webpack/Builder.pm
+++ b/lib/Mojolicious/Plugin/Webpack/Builder.pm
@@ -14,9 +14,9 @@ our $VERSION = $Mojolicious::Plugin::Webpack::VERSION || '0.01';
 
 has dependencies => sub {
   return {
-    core => [qw(webpack webpack-cli webpack-plugin-hash-output html-webpack-plugin)],
-    css  => [qw(css-loader mini-css-extract-plugin optimize-css-assets-webpack-plugin)],
-    js   => [qw(@babel/core @babel/preset-env babel-loader terser-webpack-plugin)],
+    core => [qw(webpack webpack-cli html-webpack-plugin@next)],
+    css  => [qw(css-loader mini-css-extract-plugin css-minimizer-webpack-plugin)],
+    js   => [qw(@babel/core @babel/preset-env babel-loader)],
     sass => [qw(node-sass sass-loader)],
     vue  => [qw(vue vue-loader vue-template-compiler)],
   };

--- a/lib/Mojolicious/Plugin/Webpack/webpack.config.js
+++ b/lib/Mojolicious/Plugin/Webpack/webpack.config.js
@@ -8,7 +8,6 @@ const shareDir = process.env.WEBPACK_SHARE_DIR || './assets';
 const sourceMap = process.env.WEBPACK_SOURCE_MAPS ? true : isDev ? true : false;
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const HashOutput = require('webpack-plugin-hash-output');
 
 const config = {
   mode: isDev ? 'development' : 'production',
@@ -20,10 +19,10 @@ const config = {
   },
   output: {
     filename: isDev ? '[name].development.js' : '[name].[chunkhash].js',
-    path: outDir
+    path: outDir,
+    publicPath: ''
   },
   plugins: [
-    new HashOutput(),
     new HtmlWebpackPlugin({
       cache: true,
       filename: './webpack.' + (process.env.WEBPACK_CUSTOM_NAME ? process.env.WEBPACK_CUSTOM_NAME : isDev ? 'development' : 'production') + '.html',
@@ -39,7 +38,7 @@ const config = {
 
 if (process.env.WEBPACK_RULE_FOR_JS) {
   const TerserPlugin = require('terser-webpack-plugin');
-  config.optimization.minimizer.push(new TerserPlugin({cache: true, parallel: true, sourceMap: sourceMap}));
+  config.optimization.minimizer.push(new TerserPlugin({ parallel: true }));
   config.module.rules.push({
     test: /\.js$/,
     exclude: /node_modules/,
@@ -55,7 +54,7 @@ if (process.env.WEBPACK_RULE_FOR_CSS || process.env.WEBPACK_RULE_FOR_SASS) {
     filename: isDev ? '[name].development.css' : '[name].[contenthash].css',
   }));
 
-  const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+  const OptimizeCSSAssetsPlugin = require('css-minimizer-webpack-plugin');
   config.optimization.minimizer.push(new OptimizeCSSAssetsPlugin({}));
 }
 


### PR DESCRIPTION
These changes will allow to work with webpack 5+, which I think should be the new default.

webpack 5 introduced a lot of breaking changes, I just fixed the minimum to pass current test, specially t/example-build-assets.t test.

They are big changes though, and I am not very sure of the full implicances (I am not an expert on webpack, but I have been using it since several months). I have a version running in my computer with these changes and running webpack 5, and seem to work fine, but other than that I can't tell.

There is also a specific [guide](https://webpack.js.org/migrate/5/) on webpack site, that can address further needed changes, but I didn't need to follow it because the changes introduced by this PR were enough in my case.

## Some breaking changes  considered:

- I needed to specify @next on html-webpack-plugin, otherwise it install the former version (for webpack 4)
- terser-webpack-plugin doesn't support cache nor sourceMap options, so I removed those
- optimize-css-assets-webpack-plugin is not supported anymore. I used css-minimizer-webpack-plugin to replace it
- contenthash seem to be generated ok without webpack-plugin-hash-output, so I removed it because caused lots of warnings

## Quick testing
  It can be dificult to migrate from a installed webpack 4 to 5 in the middle of a project, so in my repo there is a branch 'test-container' that can be used as a smoke test if  you change anything. Has a minimal Dockerfile to have a perl 5.32 container with npm installed.

  Just checkout to that branch and run:

```shell
docker build -t test-cont . && docker run -e TEST_ALL=1 -t test-cont prove -l t/example-build-assets.t
```